### PR TITLE
fix: SEO essentials, env docs, and custom error pages (#57, #52, #58)

### DIFF
--- a/improvements.md
+++ b/improvements.md
@@ -169,13 +169,13 @@ pwv2/
 |---|------|-------------|
 | 1 | **CI/CD Pipeline** | GitHub Actions to auto-run tests and deploy on push — replace all manual steps |
 | 2 | **Analytics** | Add GA4 or privacy-first alternative (Plausible/Fathom) to track visitors, clicks, and conversions |
-| 3 | **SEO Essentials** | Meta tags, Open Graph, Twitter Cards, sitemap.xml, robots.txt, and JSON-LD structured data |
+| ~~3~~ | ~~**SEO Essentials**~~ | ✅ **Fixed #52** — `sitemap.xml` created, `robots.txt` updated with Sitemap reference and `/admin` disallow. JSON-LD Person + WebSite schema added to `public/index.html`. Meta/OG/Twitter already present. |
 | 4 | **Error Monitoring** | Sentry (or similar) on both frontend and backend to catch and alert on runtime errors |
 | 5 | **Uptime Monitoring** | UptimeRobot or Better Uptime to alert immediately when the site goes down |
 | 6 | **Contact Form Real Backend** | Replace `mailto:` with a real email delivery service (Resend, SendGrid, or Nodemailer) |
 | 7 | **Database Backups** | Automated PostgreSQL backup schedule with offsite storage and a tested restore process |
-| 8 | **Environment Docs (.env.example)** | Document all required environment variables in a `.env.example` file committed to the repo |
-| 9 | **Custom Error Pages** | Custom 404 and 500 pages so users never hit a blank screen on broken routes |
+| ~~8~~ | ~~**Environment Docs (.env.example)**~~ | ✅ **Fixed #57** — `.env.example` was already complete with all required vars documented. |
+| ~~9~~ | ~~**Custom Error Pages**~~ | ✅ **Fixed #58** — Created `NotFound.js` (404) and `ErrorBoundary.js` (500) in `src/components/errors/`. Added `*` catch-all route in `App.js`. Playwright confirmed `/this-does-not-exist` renders the 404 page. |
 | 10 | **Server-Side Logging** | Request logging on the Express backend (Morgan + Winston) for debugging production issues |
 
 ---

--- a/public/index.html
+++ b/public/index.html
@@ -27,6 +27,31 @@
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
 
     <title>Aaron Adams - Full Stack Web Developer | Portfolio</title>
+
+    <!-- JSON-LD Structured Data -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Person",
+      "name": "Aaron Adams",
+      "url": "https://aaronadams.dev",
+      "jobTitle": "Full-Stack Developer & Marketing Strategist",
+      "description": "Full Stack Web Developer specializing in React, JavaScript, and modern web technologies.",
+      "sameAs": [
+        "https://github.com/aaronadams62",
+        "https://linkedin.com/in/aaronadams62"
+      ],
+      "knowsAbout": ["React", "JavaScript", "TypeScript", "Node.js", "PostgreSQL", "Docker", "Python"]
+    }
+    </script>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "WebSite",
+      "name": "Aaron Adams Portfolio",
+      "url": "https://aaronadams.dev"
+    }
+    </script>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,6 @@
 # https://www.robotstxt.org/robotstxt.html
 User-agent: *
-Disallow:
+Disallow: /admin
+Disallow: /admin/dashboard
+
+Sitemap: https://aaronadams.dev/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://aaronadams.dev/</loc>
+    <lastmod>2026-02-22</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>1.0</priority>
+  </url>
+</urlset>

--- a/src/App.js
+++ b/src/App.js
@@ -10,6 +10,8 @@ import Contact from './components/contact/contact';
 import Footer from './components/footer/footer';
 import AdminLogin from './components/admin/AdminLogin';
 import AdminDashboard from './components/admin/AdminDashboard';
+import NotFound from './components/errors/NotFound';
+import ErrorBoundary from './components/errors/ErrorBoundary';
 import 'slick-carousel/slick/slick.css';
 import 'slick-carousel/slick/slick-theme.css';
 import { library } from '@fortawesome/fontawesome-svg-core';
@@ -39,13 +41,16 @@ function MainSite() {
 
 function App() {
   return (
-    <Router>
-      <Routes>
-        <Route path="/" element={<MainSite />} />
-        <Route path="/admin" element={<AdminLogin />} />
-        <Route path="/admin/dashboard" element={<AdminDashboard />} />
-      </Routes>
-    </Router>
+    <ErrorBoundary>
+      <Router>
+        <Routes>
+          <Route path="/" element={<MainSite />} />
+          <Route path="/admin" element={<AdminLogin />} />
+          <Route path="/admin/dashboard" element={<AdminDashboard />} />
+          <Route path="*" element={<NotFound />} />
+        </Routes>
+      </Router>
+    </ErrorBoundary>
   );
 }
 

--- a/src/components/errors/ErrorBoundary.js
+++ b/src/components/errors/ErrorBoundary.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import './errors.css';
+
+class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error, info) {
+    console.error('ErrorBoundary caught:', error, info);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="error-page">
+          <div className="error-page__content">
+            <span className="error-page__code">500</span>
+            <h1 className="error-page__title">Something Went Wrong</h1>
+            <p className="error-page__message">
+              An unexpected error occurred. Please refresh the page or come back later.
+            </p>
+            <button className="error-page__btn" onClick={() => window.location.href = '/'}>
+              Back to Home
+            </button>
+          </div>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/src/components/errors/NotFound.js
+++ b/src/components/errors/NotFound.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import './errors.css';
+
+function NotFound() {
+  return (
+    <div className="error-page">
+      <div className="error-page__content">
+        <span className="error-page__code">404</span>
+        <h1 className="error-page__title">Page Not Found</h1>
+        <p className="error-page__message">
+          Looks like this page doesn't exist. Maybe it moved, or maybe it never existed.
+        </p>
+        <Link to="/" className="error-page__btn">Back to Home</Link>
+      </div>
+    </div>
+  );
+}
+
+export default NotFound;

--- a/src/components/errors/errors.css
+++ b/src/components/errors/errors.css
@@ -1,0 +1,57 @@
+.error-page {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--bg-primary, #0a0a0f);
+  padding: 2rem;
+}
+
+.error-page__content {
+  text-align: center;
+  max-width: 480px;
+}
+
+.error-page__code {
+  display: block;
+  font-size: clamp(6rem, 20vw, 10rem);
+  font-weight: 800;
+  line-height: 1;
+  background: linear-gradient(135deg, #667eea, #764ba2);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  margin-bottom: 1rem;
+}
+
+.error-page__title {
+  font-size: clamp(1.5rem, 4vw, 2.5rem);
+  color: var(--text-primary, #ffffff);
+  margin-bottom: 1rem;
+}
+
+.error-page__message {
+  color: var(--text-secondary, #a0a0b0);
+  font-size: 1.1rem;
+  line-height: 1.6;
+  margin-bottom: 2rem;
+}
+
+.error-page__btn {
+  display: inline-block;
+  padding: 0.875rem 2rem;
+  background: linear-gradient(135deg, #667eea, #764ba2);
+  color: #ffffff;
+  text-decoration: none;
+  border: none;
+  border-radius: 8px;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.error-page__btn:hover {
+  opacity: 0.9;
+  transform: translateY(-2px);
+}


### PR DESCRIPTION
## Summary

- **#57 — .env.example**: Already complete from a prior session. Verified all vars documented; closed with no code changes.
- **#52 — SEO Essentials**: Created `public/sitemap.xml`, updated `robots.txt` (added `/admin` disallow + Sitemap directive), added JSON-LD `Person` and `WebSite` structured data to `public/index.html`.
- **#58 — Custom Error Pages**: Built `NotFound.js` (404) and `ErrorBoundary.js` (500 catch) with shared `errors.css` matching the premium dark theme. Wired `*` catch-all route and `ErrorBoundary` wrapper into `App.js`.

## Test plan

- [x] Playwright: `http://localhost:3000/this-does-not-exist` renders 404 page with "Page Not Found" heading and "Back to Home" link
- [x] Playwright: `http://localhost:3000` still loads correctly — no regressions
- [x] `public/sitemap.xml` created and valid
- [x] `public/robots.txt` disallows `/admin` routes, references sitemap
- [x] JSON-LD blocks present in `public/index.html`
- [x] GitHub issues #57, #52, #58 closed with verbose comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)